### PR TITLE
Fix problem with update(byte) method

### DIFF
--- a/java/src/org/bouncycastle/crypto/digests/Skein.java
+++ b/java/src/org/bouncycastle/crypto/digests/Skein.java
@@ -445,7 +445,7 @@ public class Skein implements ExtendedDigest {
     }
 
     public void update(byte in) {
-        byte[] tmp = new byte[1];
+        byte[] tmp = new byte[] { in };
         update(tmp, 0, 1);
     }
 


### PR DESCRIPTION
The array was created without adding the input byte to it,
which would cause the update to be with a single zero byte,
not the input byte.
